### PR TITLE
Add DCL to singleton class

### DIFF
--- a/oslo_service/service.py
+++ b/oslo_service/service.py
@@ -119,10 +119,11 @@ class Singleton(type):
     _semaphores = lockutils.Semaphores()
 
     def __call__(cls, *args, **kwargs):
-        with lockutils.lock('singleton_lock', semaphores=cls._semaphores):
-            if cls not in cls._instances:
-                cls._instances[cls] = super(Singleton, cls).__call__(
-                    *args, **kwargs)
+        if cls not in cls._instances:
+            with lockutils.lock('singleton_lock', semaphores=cls._semaphores):
+                if cls not in cls._instances:
+                    cls._instances[cls] = super(Singleton, cls).__call__(
+                        *args, **kwargs)
         return cls._instances[cls]
 
 


### PR DESCRIPTION
Adding Double-checked locking reduce the overhead of acquiring a lock by testing the locking criterion (the "lock hint") before acquiring the lock.
https://en.wikipedia.org/wiki/Double-checked_locking